### PR TITLE
Removing <header> tags from App.jsx

### DIFF
--- a/require-auth/src/App.jsx
+++ b/require-auth/src/App.jsx
@@ -32,9 +32,6 @@ const App = () => {
     return (
         <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
             <Container text style={{ marginTop: '7em' }} className="App">
-                <header className="App-header">
-                    <Navbar />
-                </header>
                 <main>
                     <Routes />
                 </main>


### PR DESCRIPTION
The issue described in this sample is that a portion of the app is still loaded prior to authentication. Per FedRAMP requirements, the user must be totally removed from the app until authenticated. Further introspection into the code revealed that we were loading the NavBar in the sample, giving the appearance of the page loading some information before being redirected away to the authentication pages. To simplify this experience I removed the `<header>` block from the DOM. Still the `<Routes />` tag is still present in the `<main>` block. I recommend moving `<Routes />` to the container block and build the loading and authenticated landing pages in their respective components. You can also replace the loading text with whatever page style will be more visually pleasing while satisfying your FedRAMP requirements.